### PR TITLE
Escaped table name.

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -64,7 +64,7 @@ end
 MySQL.ready(function()
 	Citizen.Wait(1500)
 
-	MySQL.Async.fetchAll('SELECT * FROM properties', {}, function(properties)
+	MySQL.Async.fetchAll('SELECT * FROM `properties`', {}, function(properties)
 
 		for i=1, #properties, 1 do
 			local entering  = nil


### PR DESCRIPTION
I spent ages on this trying to understand why properties weren't showing up. I put in debug messages in the loop on the function which processes the records but they weren't being shown. When I put in the MySql escape characters it all started to work.

Without the backticks escaping the name 0 records are being returned. This is possibly a paltform difference between MySql and MariaDb. I initall setup my database for NFive which stipulated MariaDb as preferred dbms with CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci. I abandoned this effort but had the MariaDb instance in place so am using it for current ESX work. For a live server we are building we tried ESX V2 which stated the same collation as a requirement and ONLY runs on MariaDb. I'm not sure why this issue hasn't arisen before other than it must be isolated to MariaDb.

